### PR TITLE
Feature/hu9 send sms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,8 @@ NAMEDB=
 
 #Token jwt
 TOKEN=
+
+#Twilio sms
+ACCOUNT_SID=
+AUTH_TOKEN=
+PHONE_NUMBER=

--- a/controllers/sms.controller.js
+++ b/controllers/sms.controller.js
@@ -1,0 +1,10 @@
+import { constants } from "../services/utils/constants.js";
+import { response } from "../services/utils/response.js";
+import { twilioService } from "../services/twilio.service.js";
+
+const { status,message } = constants.response;
+
+export const send_sms = async (req, res) => {
+  const response = await twilioService(req);
+  res.status(status.OK).json(response.body);
+};

--- a/controllers/sms.controller.js
+++ b/controllers/sms.controller.js
@@ -5,6 +5,6 @@ import { twilioService } from "../services/twilio.service.js";
 const { status,message } = constants.response;
 
 export const send_sms = async (req, res) => {
-  const response = await twilioService(req);
-  res.status(status.OK).json(response.body);
+  const responseTwilio = await twilioService(req);
+  res.status(status.OK).json(response(true, message.send_sms, responseTwilio.body));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "bcrypt": "5.1.1",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "express": "4.19.2",
         "joi": "17.13.3",
         "jsonwebtoken": "9.0.2",
-        "mongoose": "8.4.4"
+        "mongoose": "8.4.4",
+        "twilio": "^5.2.2"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -168,6 +170,23 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -273,6 +292,18 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -327,6 +358,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -349,6 +386,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -379,6 +425,18 @@
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -495,6 +553,40 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1260,6 +1352,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1355,6 +1453,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/scmp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
+      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.6.2",
@@ -1545,6 +1649,24 @@
         "node": ">=14"
       }
     },
+    "node_modules/twilio": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.2.2.tgz",
+      "integrity": "sha512-t2Nd8CvqAc0YxbJghKYQl1Vxc7e6SrWk4U28wwkarUohGcsUMLsGpYeGXKw1Va0KB9TGVZYCs8dcP4TdLJUN9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.8",
+        "dayjs": "^1.11.9",
+        "https-proxy-agent": "^5.0.0",
+        "jsonwebtoken": "^9.0.2",
+        "qs": "^6.9.4",
+        "scmp": "^2.1.0",
+        "xmlbuilder": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1618,6 +1740,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   "dependencies": {
     "bcrypt": "5.1.1",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "express": "4.19.2",
     "joi": "17.13.3",
     "jsonwebtoken": "9.0.2",
-    "mongoose": "8.4.4"
+    "mongoose": "8.4.4",
+    "twilio": "^5.2.2"
   }
 }

--- a/routes/main.route.js
+++ b/routes/main.route.js
@@ -1,12 +1,17 @@
 import { Router } from "express";
 import { test } from "../controllers/main.controller.js";
 import auth_router from "./auth.route.js";
+import { send_sms } from "../controllers/sms.controller.js";
+import { valid_token } from "../services/middleware/valid-token.js";
+import { get_user } from "../services/middleware/get-user.js";
 
 const router = Router();
 
 router.get("/test", test);
 
 router.use("/auth", auth_router);
+
+router.post("/send/sms", valid_token, get_user, send_sms);
 
 //router.use('/question', valid_token, )
 

--- a/services/middleware/get-user.js
+++ b/services/middleware/get-user.js
@@ -1,0 +1,25 @@
+import jwt from "jsonwebtoken";
+import { constants } from "../utils/constants.js";
+import { response } from "../utils/response.js";
+
+export const get_user = async (req, res, next) => {
+  const { status, message } = constants.response;
+  const { authorization } = req.headers;
+
+  if (!authorization)
+    return res.status(status.not_auth).json(response(false, message.not_auth));
+
+  try {
+    const decoded = jwt.verify(authorization, process.env.TOKEN);
+    const user = decoded.name;
+
+    if (!user)
+      return res
+        .status(status.not_auth)
+        .json(response(false, message.not_auth));
+    req.user = user;
+    next();
+  } catch (error) {
+    res.status(status.not_auth).json(response(false, message.not_jwt));
+  }
+};

--- a/services/twilio.service.js
+++ b/services/twilio.service.js
@@ -1,0 +1,30 @@
+import twilio from "twilio";
+import dotenv from "dotenv";
+import { constants } from "./utils/constants.js";
+import { response } from "./utils/response.js";
+import { isValidPhoneNumber } from "./validations/phone.validation.js";
+
+dotenv.config();
+
+const { ACCOUNT_SID, AUTH_TOKEN, PHONE_NUMBER } = process.env;
+
+const client = twilio(ACCOUNT_SID, AUTH_TOKEN);
+
+const { message } = constants.response;
+
+export const twilioService = async (req) => {
+  const to = req.body.cel;
+  const nickname = req.user;
+
+  if (!isValidPhoneNumber(to)) {
+    return response(false, message.invalid_phone);
+  }
+
+  const messageBody = `${nickname} te ha invitado a jugar trivia de Marvel, regístrate para clasificarte en el ranking de todos los jugadores. ¡Demuestra que eres el mejor! https://marvelplay.dev`;
+
+  return client.messages.create({
+    body: messageBody,
+    from: PHONE_NUMBER,
+    to,
+  });
+};

--- a/services/utils/constants.js
+++ b/services/utils/constants.js
@@ -3,13 +3,18 @@ export const constants = {
         status: {
             OK: 200,
             not_found: 404,
-            not_auth: 401
+            not_auth: 401,
+            bad_request: 400,
+            not_valid: 422,
+            server_error: 500,
         },
         message: {
             OK: 'Server on',
             not_found: 'Not found',
             not_auth: 'Not Authorized',
-            not_jwt: 'Not Valid JWT'
+            not_jwt: 'Not Valid JWT',
+            invalid_phone: 'Invalid phone number',
+            send_sms: 'Message sent',
         }
     }
 }

--- a/services/validations/phone.validation.js
+++ b/services/validations/phone.validation.js
@@ -1,0 +1,4 @@
+export const isValidPhoneNumber = (phoneNumber) => {
+    const regex = /^(?:\+57|57)?[1-9][0-9]{9}$/;
+    return regex.test(phoneNumber); 
+}


### PR DESCRIPTION
feat: Implementar API para enviar SMS con integración de middleware de usuario

- Agregar ruta POST '/api/sms/send' para enviar SMS.
- Implementar middleware 'valid_token' para validar el token JWT en la solicitud.
- Integrar middleware 'getUser' para obtener información del usuario basada en el token validado.
- Actualizar controlador 'sendSMS' para enviar mensajes personalizados usando el nombre de usuario del remitente.
- Asegurar manejo de errores y validación de números de teléfono.
